### PR TITLE
microk8sコマンドが存在する場合のkubectlエイリアス追加 (Created by Claude AI)

### DIFF
--- a/shell/bash/default.bashrc
+++ b/shell/bash/default.bashrc
@@ -3,9 +3,14 @@ alias ll='ls -alF --color=auto'
 alias la='ls -A --color=auto'
 alias l='ls -CF --color=auto'
 
-# kubeclt 
+# kubectl 
 alias kc='kubectl'
 alias mkc='microk8s kubectl'
+
+# microk8sが存在する場合、kubectlコマンドをmicrok8s kubectlにエイリアス
+if command -v microk8s >/dev/null 2>&1; then
+    alias kubectl='microk8s kubectl'
+fi
 
 # docker 
 alias dc='docker compose'


### PR DESCRIPTION
# microk8sコマンドが存在する場合のkubectlエイリアス追加

**このPRはAIエージェントのClaudeによって作成されました。**

## 変更内容

- microk8sコマンドが存在する場合に、kubectlコマンドをmicrok8s kubectlにエイリアスする設定を追加しました。
- システム上でmicrok8sが利用可能な場合のみ、このエイリアスが有効になります。

## 実装詳細

```bash
# microk8sが存在する場合、kubectlコマンドをmicrok8s kubectlにエイリアス
if command -v microk8s >/dev/null 2>&1; then
    alias kubectl='microk8s kubectl'
fi
```

この設定により、microk8sがインストールされている環境では、kubectlコマンドを実行すると自動的にmicrok8s kubectlが実行されるようになります。
