### PR TITLE
nvim: 選択範囲を @ファイル名#L行番号 形式でコピーする <leader>cls を追加

### DIFF
--- a/dot_config/nvim/lua/keymap/native.lua
+++ b/dot_config/nvim/lua/keymap/native.lua
@@ -64,6 +64,25 @@ vim.keymap.set("v", "<leader>go", function()
   vim.fn.system('gh browse "' .. file .. ":" .. line_range .. '"')
 end, { desc = "Open selected range in GitHub" })
 
+-- 選択範囲を @ファイル名#L行番号 形式でクリップボードにコピーする
+-- '<,'> はビジュアルモードを抜けるまで更新されないため、選択中でも正しい範囲が
+-- 取れる line("v") / line(".") を使う
+vim.keymap.set("v", "<leader>cls", function()
+  local file = vim.fn.expand("%:.")
+  local start_line = vim.fn.line("v")
+  local end_line = vim.fn.line(".")
+  if start_line > end_line then
+    start_line, end_line = end_line, start_line
+  end
+  local ref = "@" .. file .. "#L" .. start_line
+  if end_line ~= start_line then
+    ref = ref .. "-L" .. end_line
+  end
+  vim.fn.setreg("+", ref)
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+  vim.notify("copied: " .. ref)
+end, { desc = "Copy @file#Lline reference", noremap = true, silent = true })
+
 -- 現在行を最後に変更したPRをブラウザで開く
 -- git blameでコミットを特定し、GitHub APIでそのコミットに紐づくPRを取得する
 local function trace_pr()

--- a/dot_config/nvim/lua/plugins/plugin.lua
+++ b/dot_config/nvim/lua/plugins/plugin.lua
@@ -69,7 +69,6 @@ return {
 		},
 		keys = {
 			{ "<leader>cl", "<cmd>ClaudeCode<cr>", mode = "n", desc = "Open Claude Code" },
-			{ "<leader>cls", "<cmd>ClaudeCodeSend<cr>", mode = "v", desc = "Send to Claude" },
 		},
 	},
 	{


### PR DESCRIPTION
## 概要

visual mode で選択した範囲を `@ファイル名#L行番号` 形式（例: `@dot_config/nvim/init.lua#L2-L4`）でクリップボードにコピーする `<leader>cls` を追加する。Claude Code のプロンプトなどへファイル参照を貼り付ける用途を想定。

関連issue: なし

## 背景・判断

- `<leader>cls` は claudecode.nvim の ClaudeCodeSend（visual mode）に割り当て済みで衝突していたため、ClaudeCodeSend のキー定義を削除した（ユーザー確認済み）。`:ClaudeCodeSend` コマンド自体は引き続き使用できる
- 範囲の取得に `'<` / `'>` マークではなく `line("v")` / `line(".")` を使用した。マークはビジュアルモードを抜けるまで更新されず、選択中に発動すると直前の選択範囲を拾うため
- `init.lua` で `clipboard=unnamedplus` を設定済みのため、書き込み先は `+` レジスタのみとした
- 行範囲は GitHub パーマリンクと同じ `L開始-L終了` 形式。パスは cwd からの相対パスで、既存の `<leader>go` と同じ方針
- コピー後はノーマルモードへ自動で戻る

## 検証

headless nvim（`nvim --headless -l`）で実際にビジュアル選択してマッピングを発動するテストを実行し、以下を確認した。

- 複数行選択で `@file#L2-L4` 形式になること
- 逆方向（下から上へ）の選択でも開始・終了行が正しく並ぶこと
- 単一行選択で `@file#L3` 形式になること
- 発動後にノーマルモードへ戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)