### PR TITLE
Add auto-rename Stop hook for session names

### DIFF
--- a/dot_claude/hooks/executable_auto-rename-hook.sh
+++ b/dot_claude/hooks/executable_auto-rename-hook.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Stop hook: 応答完了のたびに、会話内容からセッション名を自動生成して rename する。
+# 時間のかかる処理（モデル呼び出し）は auto-rename-worker.sh に切り離して
+# バックグラウンドで実行し、hook 自体は即座に終了して応答をブロックしない。
+set -euo pipefail
+
+INPUT="$(cat)"
+
+# worker 内の claude -p は --setting-sources "" で user settings（この hook 含む）を
+# 読まない設定にしているが、万一読まれた場合に再帰起動しないための保険
+if [[ -n "${AUTO_RENAME_INNER:-}" ]]; then
+    exit 0
+fi
+
+SID="$(printf '%s' "$INPUT" | jq -r '.session_id // empty')"
+TRANSCRIPT="$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty')"
+if [[ -z "$SID" || -z "$TRANSCRIPT" ]]; then
+    exit 0
+fi
+
+WORKER="$(cd "$(dirname "$0")" && pwd)/auto-rename-worker.sh"
+if [[ ! -x "$WORKER" ]]; then
+    exit 0
+fi
+
+nohup "$WORKER" "$SID" "$TRANSCRIPT" >/dev/null 2>&1 &
+disown 2>/dev/null || true
+exit 0

--- a/dot_claude/hooks/executable_auto-rename-worker.sh
+++ b/dot_claude/hooks/executable_auto-rename-worker.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# auto-rename-hook.sh から切り離されて起動される非同期 worker。
+# セッションの transcript からテキストを抜粋して haiku に渡し、
+# 「<タスク名>_<現在の状況>」形式の日本語セッション名を生成して反映する。
+# 実行記録は ~/.claude/auto-rename/worker.log に残る。
+#
+# 環境変数による上書き（主にテスト用）:
+#   AUTO_RENAME_SCRIPT: rename_session.sh のパス
+#   AUTO_RENAME_MODEL:  名前生成に使うモデル
+set -euo pipefail
+
+SID="${1:?usage: auto-rename-worker.sh <session-id> <transcript-path>}"
+TRANSCRIPT="${2:?usage: auto-rename-worker.sh <session-id> <transcript-path>}"
+
+STATE_DIR="${HOME}/.claude/auto-rename"
+LOG="${STATE_DIR}/worker.log"
+RENAME_SCRIPT="${AUTO_RENAME_SCRIPT:-${HOME}/.claude/skills/rename-session/scripts/rename_session.sh}"
+MODEL="${AUTO_RENAME_MODEL:-claude-haiku-4-5-20251001}"
+
+mkdir -p "$STATE_DIR"
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [${SID:0:8}] $*" >> "$LOG"
+}
+
+# ログの肥大化防止
+if [[ -f "$LOG" && "$(wc -c < "$LOG")" -gt 200000 ]]; then
+    tail -c 100000 "$LOG" > "${LOG}.tmp.$$" && mv "${LOG}.tmp.$$" "$LOG"
+fi
+
+if [[ ! -f "$TRANSCRIPT" ]]; then
+    log "skip: transcript not found: $TRANSCRIPT"
+    exit 0
+fi
+
+# 同一セッションの worker 多重起動を防ぐ。実行中なら今回は何もしない
+# （次の Stop hook でまた起動される）。flock が無い環境でも動くよう mkdir ロックを使い、
+# 異常終了で残った古いロックは回収する
+LOCK="${STATE_DIR}/${SID}.lock"
+if [[ -d "$LOCK" && -n "$(find "$LOCK" -maxdepth 0 -mmin +5 2>/dev/null)" ]]; then
+    rmdir "$LOCK" 2>/dev/null || true
+fi
+if ! mkdir "$LOCK" 2>/dev/null; then
+    log "skip: another worker is running"
+    exit 0
+fi
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
+
+# transcript(.jsonl) からユーザー/アシスタント発話のテキストだけを取り出す
+# （ツール呼び出しやツール結果の JSON は名前決めのノイズになるため除外）
+TEXT="$(jq -r '
+    select(.type == "user" or .type == "assistant")
+    | .message.content
+    | if type == "string" then .
+      elif type == "array" then ([.[] | select(.type? == "text") | .text] | join("\n"))
+      else empty end
+    | select(length > 0)
+' "$TRANSCRIPT" 2>/dev/null || true)"
+
+if [[ -z "$TEXT" ]]; then
+    log "skip: no text content in transcript"
+    exit 0
+fi
+
+# 長い会話は冒頭（依頼内容）と末尾（現在の状況）だけをモデルに渡す
+if [[ "$(printf '%s' "$TEXT" | wc -c)" -le 10000 ]]; then
+    EXCERPT="$TEXT"
+else
+    EXCERPT="$(printf '%s' "$TEXT" | head -c 2000)
+（中略）
+$(printf '%s' "$TEXT" | tail -c 8000)"
+fi
+
+PROMPT='以下はコーディングエージェントとのセッションの会話抜粋。このセッションに「<タスク名>_<現在の状況>」形式の日本語セッション名を付けること。
+- タスク名: セッションの主タスクを表す短い名詞句（15文字以内が目安）
+- 現在の状況: 会話の末尾から判断した現在のフェーズ（例: 調査中 / 実装中 / レビュー待ち / ブロック中 / 完了）
+- 全体で30文字以内。出力は名前だけを1行で。引用符・説明・前置きを付けない'
+
+# --setting-sources "" で user settings を読ませず、内側セッションでの Stop hook 再帰を防ぐ。
+# AUTO_RENAME_INNER は設定が読まれてしまった場合の保険（auto-rename-hook.sh 側で見る）
+NAME="$(printf '%s' "$EXCERPT" | AUTO_RENAME_INNER=1 claude -p \
+    --model "$MODEL" \
+    --setting-sources "" \
+    --no-session-persistence \
+    "$PROMPT" 2>>"$LOG" || true)"
+
+# 1行目だけ採用し、セッション名に不向きな文字を除去して40文字に制限する
+NAME="$(printf '%s' "$NAME" | head -n 1 | tr -d '`"/\\' | tr -d "'" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+NAME="${NAME:0:40}"
+
+if [[ -z "$NAME" ]]; then
+    log "skip: model returned empty name"
+    exit 0
+fi
+
+if OUT="$("$RENAME_SCRIPT" "$NAME" "$SID" 2>&1)"; then
+    log "renamed to: $NAME"
+else
+    log "rename failed: $OUT"
+fi

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -32,6 +32,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/stop.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/auto-rename-hook.sh"
           }
         ]
       }

--- a/dot_claude/skills/rename-session/scripts/executable_rename_session.sh
+++ b/dot_claude/skills/rename-session/scripts/executable_rename_session.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
-# カレントセッション（CLAUDE_CODE_SESSION_ID で特定）の表示名を書き換える。
-# 対象: $CLAUDE_JOB_DIR/state.json（bgジョブのみ）と ~/.claude/sessions/<pid>.json。
-# どちらも Claude Code の非公開内部ファイルのため、構造変更で動かなくなったら要追従。
+# セッションの表示名を書き換える。対象セッションは第2引数の session-id、
+# 省略時は環境変数 CLAUDE_CODE_SESSION_ID（= カレントセッション）で特定する。
+# 書き換え対象:
+#   ~/.claude/jobs/<jobId>/state.json  bgジョブの永続ストア。agent view のbgジョブ行の表示元
+#   ~/.claude/sessions/<pid>.json      実行中セッションのレジストリ。claude agents --json の表示元
+# どちらも Claude Code の非公開の内部ファイルのため、構造変更で動かなくなったら要追従。
 set -euo pipefail
 
-NEW_NAME="${1:?usage: rename_session.sh <new-name>}"
+NEW_NAME="${1:?usage: rename_session.sh <new-name> [session-id]}"
+SID="${2:-${CLAUDE_CODE_SESSION_ID:-}}"
 SESSIONS_DIR="${HOME}/.claude/sessions"
-SID="${CLAUDE_CODE_SESSION_ID:-}"
+JOBS_DIR="${HOME}/.claude/jobs"
 
 if ! command -v jq >/dev/null 2>&1; then
     echo "error: jq is required" >&2
@@ -14,7 +18,7 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 if [[ -z "$SID" ]]; then
-    echo "error: CLAUDE_CODE_SESSION_ID is not set (run from inside a Claude Code session)" >&2
+    echo "error: session id is unknown (pass it as the 2nd arg, or run inside a Claude Code session)" >&2
     exit 1
 fi
 
@@ -30,11 +34,16 @@ rewrite_name() {
 
 updated=0
 
-if [[ -n "${CLAUDE_JOB_DIR:-}" && -f "${CLAUDE_JOB_DIR}/state.json" ]]; then
-    rewrite_name "${CLAUDE_JOB_DIR}/state.json"
-    updated=1
-fi
+# bgジョブの永続ストア: sessionId が一致する state.json を探す
+for f in "$JOBS_DIR"/*/state.json; do
+    [[ -e "$f" ]] || continue
+    if [[ "$(jq -r '.sessionId // empty' "$f")" == "$SID" ]]; then
+        rewrite_name "$f"
+        updated=1
+    fi
+done
 
+# 実行中セッションのレジストリ: sessionId が一致するファイルを探す
 for f in "$SESSIONS_DIR"/*.json; do
     [[ -e "$f" ]] || continue
     if [[ "$(jq -r '.sessionId // empty' "$f")" == "$SID" ]]; then
@@ -48,4 +57,4 @@ if [[ "$updated" -eq 0 ]]; then
     exit 1
 fi
 
-echo "renamed current session to: $NEW_NAME"
+echo "renamed session to: $NEW_NAME"


### PR DESCRIPTION
## 概要

応答完了（Stop hook）のたびにセッションの会話内容を haiku に渡し、「<タスク名>_<現在の状況>」形式の日本語セッション名を自動生成して agent view に反映する。#6 の rename-session スキルの仕組みを自動実行に拡張したもの。

関連issue: なし

## このPRの前提

#6 (add-rename-session-skill) のブランチを base にした stacked PR。#6 を先にマージすること（#6 のマージ後にブランチが削除されれば base は main に自動で付け替わる）。

## 設計判断

- 非同期化: hook 本体は stdin の JSON から session_id / transcript_path を取り出して worker を nohup で切り離すだけ（実測15ms）。モデル呼び出しは worker 側で行い、応答をブロックしない
- 再帰防止: worker 内の claude -p は --setting-sources "" で user settings を読まないため、内側セッションでこの Stop hook は発火しない。設定が読まれてしまった場合の保険として AUTO_RENAME_INNER 環境変数のガードを併用
- 多重起動防止: セッションごとの mkdir ロック。worker 実行中に次の Stop が来た場合は skip する（次の Stop で再実行される）。flock ではなく mkdir なのは macOS に flock コマンドが無いため
- 動作仕様（事前に確認済み）: 毎ターン発火（デバウンスなし）・全セッション対象・手動で付けた名前も常に上書き
- rename_session.sh の変更: hook から任意セッションを対象にできるよう session-id を第2引数で受け取れるようにした。bgジョブの state.json の特定を CLAUDE_JOB_DIR 環境変数から sessionId の走査に変更したのは、呼び出し元の環境変数に依存させないため

## 検証内容

- fake HOME 環境で worker を同期実行し、sessionId が一致するファイルのみ rename されること・nameSource=user が設定されること・パーミッション600が保持されることを確認
- entry の即時応答（15ms）・切り離した worker の完走・ロックによる多重起動 skip・AUTO_RENAME_INNER ガードを確認
- 実セッションで end-to-end 実行し、agent view の表示が変わることを確認（生成名の例: auto-rename-hook_実装中）

## マージ後に必要な操作

- chezmoi apply で ~/.claude/ に反映する
- hooks 設定はセッション開始時に読み込まれるため、適用後に開始したセッションから有効になる

## 既知の制約

- 毎ターン haiku を1回呼ぶ（1回あたり十数秒・低コストだが積算はする）。頻度を下げたい場合は worker にデバウンスを追加する
- モデルに渡す transcript 抜粋は冒頭2KB+末尾8KB。それを超える中間の文脈は名前に反映されない
- 書き換え対象（~/.claude/sessions/, ~/.claude/jobs/）は Claude Code の非公開内部ファイルのため、本体のバージョンアップで構造が変わると動かなくなる可能性がある

🤖 Generated with [Claude Code](https://claude.com/claude-code)